### PR TITLE
Fixed a problem with images size

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,5 +1,7 @@
 .coinIcon img {
-  margin-bottom: 20px;
+  margin-bottom: 20px;,
+  width: 64px,
+  height: 50px 
 }
 
 .cData {


### PR DESCRIPTION
There was previously a problem with the API sending images back that were a different resolution than the others causing it to make the page look weird.


example images before change
![image](https://user-images.githubusercontent.com/80361877/180669812-9e61f28c-aaeb-4d29-8e4b-5035f0477f8d.png)
![image](https://user-images.githubusercontent.com/80361877/180669823-bec090ba-3a4a-42ae-a89d-65ab351b613c.png)
![image](https://user-images.githubusercontent.com/80361877/180669828-c4ed098c-74f4-42b9-9ae2-051ba8254990.png)
